### PR TITLE
Replace amount range number inputs with dual-thumb slider

### DIFF
--- a/coinpurse-py/coinpurse-client/src/pages/transactions/amount-range-slider.svelte
+++ b/coinpurse-py/coinpurse-client/src/pages/transactions/amount-range-slider.svelte
@@ -1,64 +1,40 @@
 <script lang="ts">
-    import { Input } from '$lib/components/ui/input';
-    import { formatCurrency, getCurrencySymbol } from '$lib/format';
+	import { Slider } from '$lib/components/ui/slider';
+	import { formatCurrency } from '$lib/format';
 
-    interface Props {
-        min: number;
-        max: number;
-        minValue: number;
-        maxValue: number;
-        onMinChange: (value: number) => void;
-        onMaxChange: (value: number) => void;
-    }
+	interface Props {
+		min: number;
+		max: number;
+		minValue: number;
+		maxValue: number;
+		onMinChange: (value: number) => void;
+		onMaxChange: (value: number) => void;
+	}
 
-    let { min, max, minValue, maxValue, onMinChange, onMaxChange }: Props =
-        $props();
+	let { min, max, minValue, maxValue, onMinChange, onMaxChange }: Props = $props();
 
-    // Convert dollars input to cents
-    function handleMinInput(e: Event) {
-        const value = (e.target as HTMLInputElement).value;
-        const dollars = parseFloat(value) || 0;
-        onMinChange(Math.round(dollars * 100));
-    }
+	const minDollars = $derived(Math.round(min / 100));
+	const maxDollars = $derived(Math.round(max / 100));
+	const sliderValues = $derived([Math.round(minValue / 100), Math.round(maxValue / 100)]);
+	const isDisabled = $derived(minDollars === maxDollars);
 
-    function handleMaxInput(e: Event) {
-        const value = (e.target as HTMLInputElement).value;
-        const dollars = parseFloat(value) || 0;
-        onMaxChange(Math.round(dollars * 100));
-    }
-
-    const minDollars = $derived((minValue / 100).toFixed(0));
-    const maxDollars = $derived((maxValue / 100).toFixed(0));
-    const rangeDollarsMin = $derived((min / 100).toFixed(0));
-    const rangeDollarsMax = $derived((max / 100).toFixed(0));
-    const symbol = $derived(getCurrencySymbol());
+	function handleValueChange(values: number[]) {
+		onMinChange(Math.round(values[0] * 100));
+		onMaxChange(Math.round(values[1] * 100));
+	}
 </script>
 
-<div class="flex items-center gap-2">
-    <div class="flex items-center gap-1">
-        <span class="text-sm text-gray-500">{symbol}</span>
-        <Input
-            type="number"
-            class="w-24"
-            value={minDollars}
-            min={rangeDollarsMin}
-            max={rangeDollarsMax}
-            onchange={handleMinInput}
-        />
-    </div>
-    <span class="text-gray-400">–</span>
-    <div class="flex items-center gap-1">
-        <span class="text-sm text-gray-500">{symbol}</span>
-        <Input
-            type="number"
-            class="w-24"
-            value={maxDollars}
-            min={rangeDollarsMin}
-            max={rangeDollarsMax}
-            onchange={handleMaxInput}
-        />
-    </div>
-    <span class="text-xs text-gray-400">
-        ({formatCurrency(min / 100)} – {formatCurrency(max / 100)})
-    </span>
+<div class="flex min-w-0 flex-1 flex-col gap-1.5">
+	<div class="text-muted-foreground flex justify-between text-xs">
+		<span>{formatCurrency(minValue / 100)}</span>
+		<span>{formatCurrency(maxValue / 100)}</span>
+	</div>
+	<Slider
+		min={minDollars}
+		max={maxDollars}
+		step={1}
+		value={sliderValues}
+		disabled={isDisabled}
+		onValueChange={handleValueChange}
+	/>
 </div>

--- a/coinpurse-py/coinpurse-client/src/pages/transactions/transactions-filters.svelte
+++ b/coinpurse-py/coinpurse-client/src/pages/transactions/transactions-filters.svelte
@@ -264,7 +264,7 @@
 		</div>
 
 		<!-- Amount Range -->
-		<div class="flex min-w-55 max-w-87.5 flex-1 items-center gap-2">
+		<div class="flex min-w-55 max-w-87.5 flex-1 items-end gap-2">
 			<Label class="shrink-0 text-sm">{m.txn_filter_amount()}</Label>
 			<AmountRangeSlider
 				min={amountRangeMin}


### PR DESCRIPTION
Replaces the two plain <Input type="number"> fields in the transactions
filter bar with a visual dual-thumb Slider component (bits-ui, already
in the project). Selected min/max values are displayed as currency
labels above the slider track. The slider is disabled when min === max
(no transactions loaded). Parent callbacks are unchanged.

https://claude.ai/code/session_01W5Tqv28ADDKgfzwaZq13vS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Replaced numeric input fields with an interactive slider component in the amount range filter for more intuitive value selection.
  * Adjusted visual alignment of the amount range filter component for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->